### PR TITLE
[FIX] Add round of order_plan_amount and amount_untaxed in validate_sale_order_plan

### DIFF
--- a/cmo_sale_split_quote2many_order/models/sale.py
+++ b/cmo_sale_split_quote2many_order/models/sale.py
@@ -122,7 +122,7 @@ class sale_order(models.Model):
         if (self.use_merge is False) and (self.sale_order_mode is False):
             raise Warning(_("Should select sale order mode "
                             "if not use merge sale order line"))
-        if order_plan_amount != self.amount_untaxed:
+        if round(order_plan_amount, 15) != round(self.amount_untaxed, 15):
             raise Warning(_("Order plan have amount not equal with Quotation"))
         if order_plan_amount <= 0.0:
             raise Warning(_("Order plan amount must more than zero"))


### PR DESCRIPTION
พี่หนุ่ยรีวิวหน่อยครับ คือ user ไม่สามารถ convert to order ได้ ฟ้องว่า "Order plan amount not equal with Quotation" ซึ่งน่าจะเกียวกับจำนวนทศนิยมไม่เท่ากัน ผมเลยเพิ่ม จำนวนทศนิยมที่มากที่สุดที่เป็นไปได้ในการผ่าน QO ใบนี้ นั่นคือ 15 

![Selection_075](https://user-images.githubusercontent.com/24691983/55873901-0d337980-5bbb-11e9-99e2-e2b1edd2e8cb.png)

