### PR TITLE
[8.0][ENH]cmo_sale_report

### DIFF
--- a/cmo_sale_report/models/sale.py
+++ b/cmo_sale_report/models/sale.py
@@ -24,7 +24,6 @@ class SaleOrder(models.Model):
     )
     display_operating_unit = fields.Boolean(
         string="Display Operating Unit",
-        default=True,
     )
 
     @api.multi


### PR DESCRIPTION
Edit default active display OU field is false when create sale quotation.

cc. @newtratip 