### PR TITLE
Multi pages Receipt

### DIFF
--- a/cmo_customer_invoice_report/report/cmo_receipt.jrxml
+++ b/cmo_customer_invoice_report/report/cmo_receipt.jrxml
@@ -2,7 +2,7 @@
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="cmo_receipt" language="groovy" pageWidth="612" pageHeight="792" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20">
 	<property name="ireport.zoom" value="1.3310000000000004"/>
 	<property name="ireport.x" value="0"/>
-	<property name="ireport.y" value="0"/>
+	<property name="ireport.y" value="288"/>
 	<property name="OPENERP_RELATIONS" value="[&quot;invoice_line&quot;]"/>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String"/>
 	<parameter name="EVENTS_DATA_SOURCE" class="java.lang.Object"/>
@@ -330,26 +330,23 @@
 		<band/>
 	</columnFooter>
 	<pageFooter>
-		<band height="207" splitType="Stretch"/>
-	</pageFooter>
-	<lastPageFooter>
-		<band height="171">
-			<textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="true">
-				<reportElement mode="Transparent" x="412" y="21" width="160" height="20" forecolor="#000000" backcolor="#FFFFFF"/>
-				<box topPadding="1" leftPadding="3" rightPadding="3"/>
-				<textElement textAlignment="Right" verticalAlignment="Top" rotation="None" lineSpacing="Single" markup="none">
-					<font fontName="SansSerif" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Garuda.ttf" pdfEncoding="Identity-H" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.Number"><![CDATA[$F{amount_untaxed} != null ? $F{amount_untaxed} : 0]]></textFieldExpression>
-			</textField>
+		<band height="207" splitType="Stretch">
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement x="0" y="21" width="321" height="20"/>
+				<reportElement x="0" y="57" width="321" height="20"/>
 				<box topPadding="1"/>
 				<textElement textAlignment="Center" verticalAlignment="Top">
 					<font size="10" pdfFontName="Garuda.ttf" pdfEncoding="Identity-H"/>
 				</textElement>
 				<textFieldExpression class="java.lang.String"><![CDATA["(" + ($P{REPORT_LOCALE}.toString() == "en_US" ? $F{amount_untaxed_text_en} : $F{amount_untaxed_text_th}) + ")"]]></textFieldExpression>
 			</textField>
+			<textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="true">
+				<reportElement mode="Transparent" x="412" y="57" width="160" height="20" forecolor="#000000" backcolor="#FFFFFF"/>
+				<box topPadding="1" leftPadding="3" rightPadding="3"/>
+				<textElement textAlignment="Right" verticalAlignment="Top" rotation="None" lineSpacing="Single" markup="none">
+					<font fontName="SansSerif" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Garuda.ttf" pdfEncoding="Identity-H" isPdfEmbedded="false"/>
+				</textElement>
+				<textFieldExpression class="java.lang.Number"><![CDATA[$F{amount_untaxed} != null ? $F{amount_untaxed} : 0]]></textFieldExpression>
+			</textField>
 		</band>
-	</lastPageFooter>
+	</pageFooter>
 </jasperReport>


### PR DESCRIPTION
Fix only Receipt (EN/TH), by using Page Footer instead of Last Page Footer. Other forms are not good to do.

Receipt:

![image](https://user-images.githubusercontent.com/1973598/114338739-eb8c7480-9b7d-11eb-9e39-2249b77f3832.png)

Others: the read part shouldn't be in the page footer, and so, we can't fix it.

![image](https://user-images.githubusercontent.com/1973598/114338824-15de3200-9b7e-11eb-9c1c-00913cfb2148.png)
